### PR TITLE
Added demo route

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,4 +24,13 @@ class ApplicationController < ActionController::Base
     session["warden.user.user.key"][0][0]
   end
 
+  def log_in_demo
+    casey = User.find_by(email: ENV["DEMO_EMAIL"])
+    if casey
+      sign_in casey
+    else
+      return nil
+    end
+  end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,11 @@
 class UsersController < ApplicationController
+
+  def demo
+    if log_in_demo
+      redirect_to sections_path
+    else
+      redirect_to root_path
+    end
+  end
+
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,7 +4,7 @@ Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
-  # config.secret_key = '220f900baa2a0c7c2b5a19c33bbc5653b6e80cb392567ef88e7931dca0019bb6c495a2ba9070935c0bc5a3b97d64a1a205b00944d28b6ef4593d13eb078de0b4'
+  config.secret_key = '220f900baa2a0c7c2b5a19c33bbc5653b6e80cb392567ef88e7931dca0019bb6c495a2ba9070935c0bc5a3b97d64a1a205b00944d28b6ef4593d13eb078de0b4'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
 
   get "/sections/show_bargraph" => "sections#show_bargraph", as: "show_bargraph"
 
+  get '/demo' => "users#demo", as: "demo"
+
   resources :sections
   resources :users, except: [:index]
   resources :enrollments, only: [:create]


### PR DESCRIPTION
@cwshevlin @nshah20 @LoRyder1 

Howdy, fellow ExitSlippers!  As an job-seeker, I would like to be able to have a demo route to link peeps to rather than telling them "go to sign in, enter case-e....." etc.  In this pull request, I've added another route at "/demo" that will log into an account and redirect to what that person would see upon login.  Is that cool with you guys?

If it is, I need whoever is in charge of the Heroku account to add an environment variable for me to make this work.

If it's not... :(
